### PR TITLE
Changed the Zookeeper download url to archive

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,8 @@
 ansible_playbook_version: 0.1
 zookeeper_playbook_version: "0.9.2"
 zookeeper_version: 3.4.6
-zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
+zookeeper_url_base: archive.apache.org # switch to www.us.apache.org when upgrading to the latest ZK version
+zookeeper_url: https://{{zookeeper_url_base}}/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
 
 # Flag that selects if systemd or upstart will be used for the init service:
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)


### PR DESCRIPTION
Fails to download version 3.4.6 from `http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz`. The file moved to the `archive.apache.org` domain.

@daliboraleksov 